### PR TITLE
Add Carette2024 to bibliography

### DIFF
--- a/bbt.bib
+++ b/bbt.bib
@@ -446,6 +446,27 @@
   bibsource = qplbib
 }
 
+@article{Carette2024,
+  author    = {Carette, Jacques and Heunen, Chris and Kaarsgaard, Robin and Sabry, Amr},
+  title     = {With a Few Square Roots, Quantum Computing Is as Easy as Pi},
+  year      = {2024},
+  publisher = acm,
+  address   = {New York, NY, USA},
+  volume    = {8},
+  number    = {POPL},
+  doi       = {10.1145/3632861},
+  abstract  = {Rig groupoids provide a semantic model of $\Pi$, a universal classical reversible programming language over finite types. We prove that extending rig groupoids with just two maps and three equations about them results in a model of quantum computing that is computationally universal and equationally sound and complete for a variety of gate sets. The first map corresponds to an 8th root of the identity morphism on the unit $1$. The second map corresponds to a square root of the symmetry on $1+1$. As square roots are generally not unique and can sometimes even be trivial, the maps are constrained to satisfy a nondegeneracy axiom, which we relate to the Euler decomposition of the Hadamard gate. The semantic construction is turned into an extension of $\Pi$, called $\sqrt{\Pi}$, that is a computationally universal quantum programming language equipped with an equational theory that is sound and complete with respect to the Clifford gate set, the standard gate set of Clifford+T restricted to $\leq 2$ qubits, and the computationally universal Gaussian Clifford+T gate set.},
+  journal   = pacmpl,
+  month     = jan,
+  eid       = {19},
+  pages     = {546--574},
+  numpages  = {29},
+  keywords  = {quantum programming language, reversible computing, rig category, unitary quantum computing},
+  webnote   = {POPL '24},
+  bibsource = qplbib
+}
+
+
 @article{Carette2025,
   author    = {Carette, Jacques and Heunen, Chris and Kaarsgaard, Robin and Sabry, Amr},
   title     = {How to Bake a Quantum Π},

--- a/biblatex.bib
+++ b/biblatex.bib
@@ -408,6 +408,23 @@
   bibsource    = qplbib
 }
 
+@article{Carette2024,
+  author       = {Carette, Jacques and Heunen, Chris and Kaarsgaard, Robin and Sabry, Amr},
+  title        = {With a Few Square Roots, Quantum Computing Is as Easy as Pi},
+  year         = {2024},
+  volume       = {8},
+  number       = {POPL},
+  doi          = {10.1145/3632861},
+  abstract     = {Rig groupoids provide a semantic model of $\Pi$, a universal classical reversible programming language over finite types. We prove that extending rig groupoids with just two maps and three equations about them results in a model of quantum computing that is computationally universal and equationally sound and complete for a variety of gate sets. The first map corresponds to an 8th root of the identity morphism on the unit $1$. The second map corresponds to a square root of the symmetry on $1+1$. As square roots are generally not unique and can sometimes even be trivial, the maps are constrained to satisfy a nondegeneracy axiom, which we relate to the Euler decomposition of the Hadamard gate. The semantic construction is turned into an extension of $\Pi$, called $\sqrt{\Pi}$, that is a computationally universal quantum programming language equipped with an equational theory that is sound and complete with respect to the Clifford gate set, the standard gate set of Clifford+T restricted to $\leq 2$ qubits, and the computationally universal Gaussian Clifford+T gate set.},
+  journaltitle = pacmpl,
+  month        = jan,
+  eid          = {19},
+  keywords     = {quantum programming language, reversible computing, rig category, unitary quantum computing},
+  webnote      = {POPL '24},
+  bibsource    = qplbib
+}
+
+
 @article{Carette2025,
   author       = {Carette, Jacques and Heunen, Chris and Kaarsgaard, Robin and Sabry, Amr},
   title        = {How to Bake a Quantum Π},


### PR DESCRIPTION
Adds the missed POPL 2024 paper "With a Few Square Roots, Quantum Computing Is as Easy as Pi" to bbt.bib and biblatex.bib.

Fixes #14

---
*PR created automatically by Jules for task [15551373893063940374](https://jules.google.com/task/15551373893063940374) started by @k4rtik*