### PR TITLE
Fix broken bibtex output from biber

### DIFF
--- a/bibtex-compatibility.py
+++ b/bibtex-compatibility.py
@@ -20,41 +20,50 @@ month_names = {
   12: "dec"
 }
 
+if len(sys.argv) < 2:
+    print("Usage: python3 bibtex-compatibility.py <db_name>")
+    sys.exit(1)
+
 db_name = sys.argv[1]
 
-old_db = open(db_name + ".bib","r")
-new_db = open("bibtex.bib","w")
+try:
+    with open(db_name + ".bib", "r") as old_db:
+        with open("bibtex.bib", "w") as new_db:
+            for line in old_db:
+                # Check for date field (specifically excluding urldate)
+                # Use ^\s*date to match from start of line, ensuring we don't match urldate
+                date_match = re.search(r"^(\s*)date\s*=\s*{(\d+)-?(\d+)?.*}", line)
+                if date_match:
+                    indent = date_match.group(1)
+                    new_db.write("{0}year = {{{1:s}}},\n".format(indent, date_match.group(2)))
+                    if date_match.group(3) is not None:
+                        month = month_names[int(date_match.group(3))]
+                        new_db.write("{0}month = {1},\n".format(indent, month))
+                    continue
 
-for line in old_db.readlines():
-    date_pattern = re.search(r"date.*{(\d+)-?(\d+)?.*}",line)
-    if date_pattern:
-        new_db.write("  year = {{{0:s}}},\n".format(date_pattern.group(1)))
-        # print "  year = {{{0:s}}},\n".format(date_pattern.group(1)),
-        if date_pattern.group(2) is not None:
-            month = month_names[int(date_pattern.group(2))];
-            new_db.write("  month = {},\n".format(month))
-    elif re.search("journaltitle",line):
-        new_db.write(line.replace("journaltitle","journal"))
-    elif re.search("location",line):
-        new_db.write(line.replace("location","address"))
-    elif re.search("eprinttype",line):
-        new_db.write(line.replace("eprinttype","archiveprefix"))
-    # the following change is not suitable for techreports
-    # elif re.search("institution",line):
-    #     new_db.write(line.replace("institution","school"))
-    elif re.search("@online",line):
-        new_db.write(line.replace("@online","@unpublished"))
-    elif re.search("@report",line):
-        new_db.write(line.replace("@report","@techreport"))
-    elif re.search("@inbook",line):
-        new_db.write(line.replace("@inbook","@incollection"))
-    elif re.search("@collection",line):
-        new_db.write(line.replace("@collection","@book"))
-    elif re.search("@thesis{Singhal2020",line):
-        new_db.write(line.replace("@thesis","@mastersthesis"))
-    elif re.search("@thesis",line):
-        new_db.write(line.replace("@thesis","@phdthesis"))
-    else:
-      new_db.write(line)
-old_db.close()
-new_db.close()
+                # Field name replacements - only when they appear as keys
+                if re.search(r"^\s*journaltitle\s*=", line):
+                    new_db.write(re.sub(r"journaltitle", "journal", line, count=1))
+                elif re.search(r"^\s*location\s*=", line):
+                    new_db.write(re.sub(r"location", "address", line, count=1))
+                elif re.search(r"^\s*eprinttype\s*=", line):
+                    new_db.write(re.sub(r"eprinttype", "archiveprefix", line, count=1))
+
+                # Entry type replacements - only at the start of entries
+                elif line.startswith("@online"):
+                    new_db.write(line.replace("@online", "@unpublished", 1))
+                elif line.startswith("@report"):
+                    new_db.write(line.replace("@report", "@techreport", 1))
+                elif line.startswith("@inbook"):
+                    new_db.write(line.replace("@inbook", "@incollection", 1))
+                elif line.startswith("@collection"):
+                    new_db.write(line.replace("@collection", "@book", 1))
+                elif line.startswith("@thesis{Singhal2020a"):
+                    new_db.write(line.replace("@thesis", "@mastersthesis", 1))
+                elif line.startswith("@thesis"):
+                    new_db.write(line.replace("@thesis", "@phdthesis", 1))
+                else:
+                    new_db.write(line)
+except FileNotFoundError:
+    print(f"Error: {db_name}.bib not found")
+    sys.exit(1)


### PR DESCRIPTION
This PR improves the `bibtex-compatibility.py` script, which is used to normalize BibLaTeX output from `biber` into standard BibTeX. The original script had several logic flaws, such as incorrectly matching `urldate` when trying to process the `date` field, and performing replacements inside field values.

The new implementation uses more precise, anchored regular expressions to ensure that only field names at the beginning of a line are replaced. It also correctly maps various BibLaTeX-specific entry types to their BibTeX equivalents and includes a specific fix for a master's thesis entry. The script has been modernized with context managers and improved error handling.

---
*PR created automatically by Jules for task [7212322488588886541](https://jules.google.com/task/7212322488588886541) started by @k4rtik*